### PR TITLE
B1239 updates

### DIFF
--- a/opgp/opgp.go
+++ b/opgp/opgp.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"strconv"
 
-	"code.google.com/p/go.crypto/openpgp"
-	"code.google.com/p/go.crypto/openpgp/armor"
-	"code.google.com/p/go.crypto/openpgp/clearsign"
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/armor"
+	"golang.org/x/crypto/openpgp/clearsign"
 )
 
 var KeyringFile = "keyring"

--- a/package/redhat
+++ b/package/redhat
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -x
 set -e
 
 if [ -z "$1" ]; then

--- a/package/redhat
+++ b/package/redhat
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -x
 set -e
 
 if [ -z "$1" ]; then

--- a/package/template.spec
+++ b/package/template.spec
@@ -53,23 +53,39 @@ rm -rf $RPM_BUILD_ROOT
 
 %pre
 /bin/mkdir -p "$(dirname "@@datadir@@")"
-/usr/sbin/useradd -c "Repo Server" -d @@datadir@@ -m -r -U repo
+if [ $1 -eq 1 ]; then
+    # New Install
+    /usr/sbin/useradd -c "Repo Server" -d @@datadir@@ -m -r -U repo
+else
+    # Upgrade
+    /sbin/service @@name@@ stop
+fi
 
 
 %post
-/sbin/chkconfig --add @@name@@
-/sbin/chkconfig @@name@@ on
+if [ $1 -eq 1 ]; then
+    # New Install
+    /sbin/chkconfig --add @@name@@
+    /sbin/chkconfig @@name@@ on
+fi
 /sbin/service @@name@@ start
 
 
 %preun
-/sbin/service @@name@@ stop
-/sbin/chkconfig @@name@@ off
-/sbin/chkconfig --del @@name@@
+if [ $1 -eq 0 ]; then
+    # Uninstall
+    /sbin/service @@name@@ stop
+    /sbin/chkconfig @@name@@ off
+    /sbin/chkconfig --del @@name@@
+fi
 
 
 %postun
-/usr/sbin/userdel repo
+if [ $1 -eq 0 ]; then
+    /usr/sbin/userdel repo
+fi
 
 
 %changelog
+* Fri Dec 2 2016 Stuart Websper
+- Fixed calculation of SHA256 / MD5SUM for Packages.gz


### PR DESCRIPTION
Updates fix issues:
- Updates to the import for the openpgp package to reflect latest location (NOTE requires go v1.4 or higher)
- Fixed issue where the SHA256 and MD5SUM were incorrectly calculated for the Packages.gz / Sources.gz files using the uncompressed data
- Fixed RPM template SPEC to support upgrade of the package.